### PR TITLE
Fixed wrong char

### DIFF
--- a/colorsys.js
+++ b/colorsys.js
@@ -324,7 +324,7 @@ colorsys.stringify = function (obj) {
   const prefix = Object.keys(obj).join('')
   const values = Object.keys(obj).map(function (key) {
     var val = obj[key]
-    if (key === 's' || key === 'v' || key === 'l') {
+    if (key === 's' || key === 'v' || key === 'l') {
       val = val + '%'
     }
     return val


### PR DESCRIPTION
It seems there is a wrong (invisible) char in colorsys.stringify function:

![captura de pantalla 2018-04-06 a las 14 07 43](https://user-images.githubusercontent.com/659832/38420538-527b9fde-39a4-11e8-9d1a-d3ce1fb013e0.png)

Probably this is the easiest PR of the history, but anyway I'm happy to help :)

Cheers!