### PR TITLE
Fix decimal

### DIFF
--- a/colorsys.js
+++ b/colorsys.js
@@ -1,4 +1,4 @@
-
+n
 const RGB_MAX = 255
 const HUE_MAX = 360
 const SV_MAX = 100
@@ -344,9 +344,17 @@ colorsys.decimal_to_hex = colorsys.decimalToHex = colorsys.decimal2Hex
 
 colorsys.decimal2Hex = function(decimalColor) {
   if (typeof decimalColor === "string") {
-    return "#" + parseInt(decimalColor).toString(16)
+    let hex = parseInt(decimalColor).toString(16)
+    while (hex.length < 6) {
+      hex = "0" + hex
+    }
+    return "#" + hex
   }
-  return "#" + decimalColor.toString(16)
+  let hex = decimalColor.toString(16)
+  while (hex.length < 6) {
+    hex = "0" + hex
+  }
+  return "#" + hex
 }
 
 // Will return a random hex colour

--- a/colorsys.js
+++ b/colorsys.js
@@ -1,4 +1,3 @@
-n
 const RGB_MAX = 255
 const HUE_MAX = 360
 const SV_MAX = 100

--- a/colorsys.js
+++ b/colorsys.js
@@ -332,6 +332,23 @@ colorsys.stringify = function (obj) {
   return prefix + '(' + values.join(', ') + ')'
 }
 
+// Google Assistant API uses this format in SmartHome Apps. Example => "spectrumRGB": 16711680
+colorsys.hex_to_decimal = colorsys.hexToDecimal = colorsys.hex2Decimal
+
+colorsys.hex2Decimal = function(hexColor) {
+  if (typeof hexColor === "string") {
+    return parseInt(hexColor.replace("#", ""), 16)
+  }
+}
+colorsys.decimal_to_hex = colorsys.decimalToHex = colorsys.decimal2Hex
+
+colorsys.decimal2Hex = function(decimalColor) {
+  if (typeof decimalColor === "string") {
+    return "#" + parseInt(decimalColor).toString(16)
+  }
+  return "#" + decimalColor.toString(16)
+}
+
 // Will return a random hex colour
 colorsys.random = function () {
   const base = '000000'

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,15 @@ describe('colorsys', function() {
     expect(rgb).to.deep.equal({ r: 255, g: 255, b: 255 })
   })
 
+  it("should convert hex <-> decimal", function() {
+    const decimal = colorsys.hex2Decimal("#66d7a9")
+    expect(decimal).to.equal(6739881)
+    let hex = colorsys.decimal2Hex(6739881)
+    expect(hex).to.equal("#66d7a9")
+    hex = colorsys.decimal2Hex("6739881")
+    expect(hex).to.equal("#66d7a9")
+  })
+
   it('should convert hex <-> rgb', function() {
     const hex = colorsys.rgb_to_hex({ r: 255, g: 0, b: 255 })
     expect(hex).to.equal('#ff00ff')


### PR DESCRIPTION
Los colores sin rojo o rojo y verde daban un string demasiado corto tipo #ff en vez de #0000ff