### PR TITLE
Fix decimal without typechecks

### DIFF
--- a/colorsys.js
+++ b/colorsys.js
@@ -341,8 +341,8 @@ colorsys.hex2Decimal = function(hexColor) {
 colorsys.decimal_to_hex = colorsys.decimalToHex = colorsys.decimal2Hex
 
 colorsys.decimal2Hex = function(decimalColor) {
-  const hex = '000000' + parseInt(decimalColor).toString(16)
-  return `#${hex}`
+  const hexInBase16 = parseInt(decimalColor).toString(16)
+  return `#${padWithZeros(hexInBase16)}`
 }
 
 // Will return a random hex colour
@@ -411,6 +411,14 @@ function _hue2Rgb (p, q, t) {
   if (t < 1 / 2) return q
   if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6
   return p
+}
+
+function padWithZeros (num) {
+  var s = String(num)
+  while (s.length < 6) {
+    s = '0' + s
+  }
+  return s
 }
 
 // It's easier to change luminosity in HSL

--- a/colorsys.js
+++ b/colorsys.js
@@ -1,4 +1,4 @@
-
+n
 const RGB_MAX = 255
 const HUE_MAX = 360
 const SV_MAX = 100
@@ -344,9 +344,17 @@ colorsys.decimal_to_hex = colorsys.decimalToHex = colorsys.decimal2Hex
 
 colorsys.decimal2Hex = function(decimalColor) {
   if (typeof decimalColor === "string") {
-    return "#" + parseInt(decimalColor).toString(16)
+    let hex = parseInt(decimalColor).toString(16)
+    while (hex.length < 6) {
+      hex = "0" + hex
+    }
+    return "#" + hex
   }
-  return "#" + decimalColor.toString(16)
+  let hex = decimalColor.toString(16)
+  while (hex.length < 6) {
+    hex = "0" + hex
+  }
+  return "#" + hex
 }
 
 // Will return a random hex colour

--- a/colorsys.js
+++ b/colorsys.js
@@ -1,4 +1,3 @@
-n
 const RGB_MAX = 255
 const HUE_MAX = 360
 const SV_MAX = 100

--- a/colorsys.js
+++ b/colorsys.js
@@ -331,29 +331,18 @@ colorsys.stringify = function (obj) {
   return prefix + '(' + values.join(', ') + ')'
 }
 
-// Google Assistant API uses this format in SmartHome Apps. Example => "spectrumRGB": 16711680
+// Google Assistant API uses this format in SmartHome Apps. Example => 'spectrumRGB': 16711680
 colorsys.hex_to_decimal = colorsys.hexToDecimal = colorsys.hex2Decimal
 
 colorsys.hex2Decimal = function(hexColor) {
-  if (typeof hexColor === "string") {
-    return parseInt(hexColor.replace("#", ""), 16)
-  }
+  return parseInt(hexColor.replace('#', ''), 16)
 }
+
 colorsys.decimal_to_hex = colorsys.decimalToHex = colorsys.decimal2Hex
 
 colorsys.decimal2Hex = function(decimalColor) {
-  if (typeof decimalColor === "string") {
-    let hex = parseInt(decimalColor).toString(16)
-    while (hex.length < 6) {
-      hex = "0" + hex
-    }
-    return "#" + hex
-  }
-  let hex = decimalColor.toString(16)
-  while (hex.length < 6) {
-    hex = "0" + hex
-  }
-  return "#" + hex
+  const hex = '000000' + parseInt(decimalColor).toString(16)
+  return `#${hex}`
 }
 
 // Will return a random hex colour

--- a/test/test.js
+++ b/test/test.js
@@ -13,13 +13,18 @@ describe('colorsys', function() {
     expect(rgb).to.deep.equal({ r: 255, g: 255, b: 255 })
   })
 
-  it("should convert hex <-> decimal", function() {
-    const decimal = colorsys.hex2Decimal("#66d7a9")
+  it('should convert hex <-> decimal', function() {
+    const decimal = colorsys.hex2Decimal('#66d7a9')
     expect(decimal).to.equal(6739881)
     let hex = colorsys.decimal2Hex(6739881)
-    expect(hex).to.equal("#66d7a9")
-    hex = colorsys.decimal2Hex("6739881")
-    expect(hex).to.equal("#66d7a9")
+    expect(hex).to.equal('#66d7a9')
+    hex = colorsys.decimal2Hex('6739881')
+    expect(hex).to.equal('#66d7a9')
+  })
+
+  it('should convert decimal integers to hex string', function () {
+    const hex = colorsys.decimal2Hex(3359829)
+    expect(hex).to.equal('#334455')
   })
 
   it('should convert hex <-> rgb', function() {


### PR DESCRIPTION
Use single quotes and show different approach
Different approach
Update colorsys.js
Fixed for colors without 'red' or 'red/green' values